### PR TITLE
Use EditSession for schematic save

### DIFF
--- a/src/main/java/me/cheezburga/skwe/api/utils/schematics/Runnables.java
+++ b/src/main/java/me/cheezburga/skwe/api/utils/schematics/Runnables.java
@@ -12,7 +12,6 @@ import com.sk89q.worldedit.function.operation.Operation;
 import com.sk89q.worldedit.function.operation.Operations;
 import com.sk89q.worldedit.math.transform.AffineTransform;
 import com.sk89q.worldedit.session.ClipboardHolder;
-import com.sk89q.worldedit.world.World;
 import me.cheezburga.skwe.api.utils.Utils;
 import me.cheezburga.skwe.api.utils.regions.RegionWrapper;
 import org.bukkit.Location;
@@ -59,13 +58,15 @@ public class Runnables {
         }
 
         return () -> {
-            try (ClipboardWriter writer = format.getWriter(new FileOutputStream(filePath.toFile()))) {
+            try (
+                    ClipboardWriter writer = format.getWriter(new FileOutputStream(filePath.toFile()));
+                    EditSession session = WorldEdit.getInstance().newEditSession(BukkitAdapter.adapt(wrapper.world()))
+            ) {
                 Clipboard clipboard = new BlockArrayClipboard(wrapper.region());
                 if (centre != null)
                     clipboard.setOrigin(Utils.toBlockVector3(centre));
 
-                World world = BukkitAdapter.adapt(wrapper.world());
-                ForwardExtentCopy copy = new ForwardExtentCopy(world, wrapper.region(), clipboard, wrapper.region().getMinimumPoint());
+                ForwardExtentCopy copy = new ForwardExtentCopy(session, wrapper.region(), clipboard, wrapper.region().getMinimumPoint());
                 copy.setSourceMask(Utils.maskFrom(preMask, null));
                 copy.setCopyingEntities(copyEntities);
                 copy.setCopyingBiomes(copyBiomes);


### PR DESCRIPTION
## Summary
- supply an EditSession when copying regions to schematics
- preserve existing mask, entity, and biome handling

## Testing
- `bash gradlew test` *(fails: Could not resolve dependencies; received 403 responses)*

------
https://chatgpt.com/codex/tasks/task_e_68c772d51da8832aafa6b6e52f43dc71