### PR TITLE
chore: bump version to 1.1.3

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group = 'me.cheezburga'
-version = '1.1.2'
+version = '1.1.3'
 
 repositories {
     mavenCentral()


### PR DESCRIPTION
## Summary
- bump project version to 1.1.3

## Testing
- `./gradlew test --no-daemon` *(fails: Could not resolve dependencies, received status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_68c7dc03e490832a887e8a933e5d8ab8